### PR TITLE
Revamp with parchment style

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Daggerheart Dice Roller</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Open+Sans:wght@400;700&family=Roboto+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./style.css">
 
 </head>
@@ -28,16 +28,15 @@
         <p class="die-label">d12</p>
       </div>
     </div>
+    <hr class="divider">
 
     <div class="controls">
       <label for="dcInput">Difficulty Class (DC) - Set to 0 for raw roll:</label>
       <input type="number" id="dcInput" value="0" min="0" max="30">
-      <button class="roll-button" onclick="rollDice()">Roll the Dice!</button>
+      <button class="menu-button" onclick="rollDice()">Roll the Dice!</button>
     </div>
 
-    <div id="outcome" class="outcome-card" style="display: none;">
-      <!-- Outcome will be displayed here -->
-    </div>
+    <div id="outcome" class="outcome-card" style="display: none;"></div>
   </div>
 </div>
 <!-- partial -->

--- a/style.css
+++ b/style.css
@@ -1,40 +1,42 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Open+Sans:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&family=Open+Sans:wght@400;700&family=Roboto+Condensed:wght@700&display=swap');
+
+:root {
+  --parchment-bg: #fdf6e3;
+  --parchment-dark: #e9e0cc;
+  --dnd-red: #8B0000;
+  --ink-black: #1a1a1a;
+}
 
 body {
-  background: linear-gradient(135deg, #1a1a2e 0%, #0f3460 100%);
-  min-height: 100vh;
-  color: #f0e6d6;
+  background-color: var(--parchment-bg);
+  background-image: url('https://www.transparenttextures.com/patterns/old-parchment.png');
+  color: var(--ink-black);
   font-family: 'Open Sans', sans-serif;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   margin: 0;
+  padding: 2rem;
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.app-container {
+  max-width: 450px;
+  width: 100%;
 }
 
 .app-title {
   font-family: 'Cinzel', serif;
-  font-size: 2.5rem;
-  background: linear-gradient(135deg, #ffd700, #ffa500);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--dnd-red);
   text-align: center;
-  margin-bottom: 1.5rem;
-}
-
-.app-container {
-  max-width: 600px;
-  width: 100%;
-  margin: 2rem auto;
+  margin-bottom: 2rem;
 }
 
 .dice-container {
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 20px;
+  background-color: rgba(255, 255, 255, 0.6);
+  border: 1px solid #c9c0ac;
+  border-radius: 8px;
   padding: 2rem;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .dice-row {
@@ -53,11 +55,11 @@ body {
 }
 
 .die-title.hope {
-  color: #ffd700;
+  color: #b8860b;
 }
 
 .die-title.fear {
-  color: #dc143c;
+  color: var(--dnd-red);
 }
 
 .die-label {
@@ -67,7 +69,7 @@ body {
 
 .controls {
   text-align: center;
-  margin-top: 1rem;
+  margin-top: 2rem;
 }
 
 .controls label {
@@ -77,28 +79,14 @@ body {
 }
 
 .controls input {
-  background: rgba(255, 255, 255, 0.1);
-  color: #f0e6d6;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background-color: var(--parchment-dark);
+  border: 1px solid #c9c0ac;
   border-radius: 4px;
   padding: 0.3rem 0.5rem;
   text-align: center;
   width: 120px;
   margin-bottom: 1rem;
-}
-
-.hope-die {
-  background: linear-gradient(135deg, #ffd700, #ffed4e);
-  color: #1a1a1a;
-  border: 3px solid #ffa500;
-  box-shadow: 0 4px 15px rgba(255, 215, 0, 0.4);
-}
-
-.fear-die {
-  background: linear-gradient(135deg, #8b0000, #dc143c);
-  color: white;
-  border: 3px solid #660000;
-  box-shadow: 0 4px 15px rgba(139, 0, 0, 0.4);
+  font-family: inherit;
 }
 
 .die-face {
@@ -114,13 +102,26 @@ body {
   transition: all 0.3s ease;
 }
 
+.hope-die {
+  background: linear-gradient(135deg, #ffd700, #ffed4e);
+  color: var(--ink-black);
+  border: 3px solid #ffa500;
+  box-shadow: 0 4px 15px rgba(255, 215, 0, 0.4);
+}
+
+.fear-die {
+  background: linear-gradient(135deg, #8b0000, #dc143c);
+  color: white;
+  border: 3px solid #660000;
+  box-shadow: 0 4px 15px rgba(139, 0, 0, 0.4);
+}
+
 .rolling {
   animation: rollDice 0.6s ease-in-out;
 }
 
 @keyframes rollDice {
-  0%,
-  100% {
+  0%, 100% {
     transform: scale(1) rotate(0deg);
   }
   25% {
@@ -135,42 +136,40 @@ body {
 }
 
 .outcome-card {
-  border-radius: 15px;
+  background-color: var(--parchment-dark);
+  border: 1px solid #c9c0ac;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
   padding: 1.5rem;
   margin-top: 2rem;
   text-align: center;
-  font-size: 1.2rem;
-  font-weight: bold;
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .hope-success {
-  background: linear-gradient(135deg, #22c55e, #86efac);
-  color: #1a1a1a;
-  border: 2px solid #16a34a;
+  color: var(--ink-black);
+  border-left: 6px solid #16a34a;
 }
 
 .fear-outcome {
-  background: linear-gradient(135deg, #dc2626, #f87171);
-  color: white;
-  border: 2px solid #991b1b;
+  color: var(--ink-black);
+  border-left: 6px solid #991b1b;
 }
 
 .success-with-fear {
-  background: linear-gradient(135deg, #ea580c, #fdba74);
-  color: white;
-  border: 2px solid #c2410c;
+  color: var(--ink-black);
+  border-left: 6px solid #c2410c;
 }
 
 .failure-with-hope {
-  background: linear-gradient(135deg, #2563eb, #93c5fd);
-  color: white;
-  border: 2px solid #1d4ed8;
+  color: var(--ink-black);
+  border-left: 6px solid #1d4ed8;
 }
 
 .critical-success {
-  background: linear-gradient(135deg, #ffd700, #fff8dc);
-  color: #1a1a1a;
-  border: 2px solid #daa520;
+  color: var(--ink-black);
+  border-left: 6px solid #daa520;
   animation: glow 2s ease-in-out infinite alternate;
 }
 
@@ -183,27 +182,37 @@ body {
   }
 }
 
-.roll-button {
-  background: linear-gradient(135deg, #4169e1, #1e90ff);
-  border: none;
-  border-radius: 50px;
-  padding: 1rem 3rem;
-  margin-top: 0.5rem;
-  font-size: 1.3rem;
-  font-weight: bold;
-  color: white;
+.menu-button {
+  background-color: transparent;
+  border: 1px solid #c9c0ac;
+  color: var(--ink-black);
+  font-family: 'Roboto Condensed', sans-serif;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  padding: 0.75rem 1.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
   cursor: pointer;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 15px rgba(65, 105, 225, 0.3);
+  transition: all 0.2s ease-in-out;
 }
 
-.roll-button:hover {
+.menu-button:hover {
+  background-color: var(--parchment-dark);
+  border-color: var(--dnd-red);
+  color: var(--dnd-red);
+  box-shadow: 0 3px 6px rgba(0,0,0,0.1);
   transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(65, 105, 225, 0.4);
 }
 
-.roll-button:active {
+.menu-button:active {
   transform: translateY(0);
+}
+
+.divider {
+  margin: 2rem 0;
+  border: none;
+  height: 1px;
+  background-image: linear-gradient(to right, transparent, var(--dnd-red) 50%, transparent);
 }
 
 /* Mobile responsiveness */
@@ -228,9 +237,8 @@ body {
     max-width: 160px;
   }
 
-  .roll-button {
+  .menu-button {
     width: 100%;
     padding: 0.8rem 1.5rem;
   }
 }
-


### PR DESCRIPTION
## Summary
- redesign with modern parchment colors and fonts
- add decorative divider and menu button styling
- integrate Roboto Condensed and responsive layout
- style the outcome card with parchment aesthetics

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_68883145c514832fbe75001ad19d9a0c