### PR TITLE
Fix dice panel overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,6 +26,7 @@ background: linear-gradient(135deg, #1d0f3b, #000, #0f0c29);
 .dice-container {
   background: rgba(30, 15, 60, 0.25); /* Translucent dark purple */
   backdrop-filter: blur(6px); /* The frosted glass blur effect */
+  position: relative; /* Ensure z-index takes effect */
   z-index: 2; /* Ensure panel is above the background animation */
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 1rem;


### PR DESCRIPTION
## Summary
- ensure the `.dice-container` has `position: relative` so its `z-index` works
- checked that `#animation-container` keeps a lower z-index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888412bd5fc832fa8135a2c049f54dc